### PR TITLE
changing TibiaDataAPIhost to dev

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	TibiaDataAPIhost = "http://127.0.0.1:8080"
+	TibiaDataAPIhost = "https://dev.tibiadata.com"
 )
 
 type AssetsHouseWorlds struct {


### PR DESCRIPTION
- changing `TibiaDataAPIhost` to `dev.tibiadata.com`

Note: mergable when https://github.com/TibiaData/tibiadata-api-go/pull/26 is merged.

Rel to #1 