### PR TITLE
changing TibiaDataAPIhost to api (prod)

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -18,7 +18,7 @@ var (
 )
 
 const (
-	TibiaDataAPIhost = "dev.tibiadata.com"
+	TibiaDataAPIhost = "api.tibiadata.com"
 )
 
 func init() {


### PR DESCRIPTION
- changing `TibiaDataAPIhost` to `api.tibiadata.com`

Fix #1