### PR TITLE
fix: add monksapparition to specialCreatures list

### DIFF
--- a/src/util.go
+++ b/src/util.go
@@ -37,6 +37,7 @@ var (
 		"lostsoulmedium":         "Mean Lost Soul",
 		"asuranight":             "Midnight Asura",
 		"lionmonk":               "Monk Of The Order",
+		"monksapparition":        "Monk's Apparition",
 		"moohtahwarrior":         "Mooh'tah Warrior",
 		"cultnovice":             "Novice Of The Cult",
 		"paladinsapparition":     "Paladin's Apparition",


### PR DESCRIPTION
This pull request includes a small change to the `src/util.go` file. The change adds a new entry to the list of character names.

* [`src/util.go`](diffhunk://#diff-e5738cb2023c90bf0365109bb7ff1f6ed167a67f3d6b8c5c86abe05269e97b76R40): Added "monksapparition" with the value "Monk's Apparition" to the list of character names.